### PR TITLE
Modifying to use the libiconv-1.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+deps/builds
+deps/downloads
+deps/src
+deps/usr
+deps/deps.jl

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -40,9 +40,9 @@ if is_windows()
 end
 
 provides(Sources,
-         URI("http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz"),
+         URI("http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.15.tar.gz"),
          libiconv,
-         SHA="72b24ded17d687193c3366d0ebe7cde1e6b18f0df8c55438ac95be39e8a30613")
+         SHA="ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178")
 
 provides(BuildProcess,
          Autotools(libtarget = "lib/libiconv.la",


### PR DESCRIPTION
libiconv-1.14 does not build on newer versions of Ubuntu. This has been reported in the issue #16. This PR is to address the same. 