### PR TITLE
Dependency check for `iconv` library modified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+deps/builds
+deps/downloads
+deps/src
+deps/usr
+deps/deps.jl

--- a/README.md
+++ b/README.md
@@ -149,3 +149,7 @@ julia> readstring(s) # Decoding happens automatically here
 Do not forget to call `close` on `StringEncoder` and `StringDecoder` objects to finish the encoding process. For `StringEncoder`, this function calls `flush`, which writes any characters still in the buffer, and possibly some control sequences (for stateful encodings). For both `StringEncoder` and `StringDecoder`, `close` checks that there are no incomplete sequences left in the input stream, and raise an `IncompleteSequenceError` if that's the case. It will also free iconv resources immediately, instead of waiting for garbage collection.
 
 Conversion currently raises an error if an invalid byte sequence is encountered in the input, or if some characters cannot be represented in the target enconding. It is not yet possible to ignore such characters or to replace them with a placeholder.
+
+## Notes on Installation on Linux OS
+
+Most Linux distributions provide `iconv` functionalities as part of the base operating system library `libc`. In normal circumstances, no additional installation of `libiconv` may be required by downloading it from the GNU repository and building from the sources. If you observe such a behavior on your operating system, file an issue with OS details.

--- a/README.md
+++ b/README.md
@@ -152,4 +152,4 @@ Conversion currently raises an error if an invalid byte sequence is encountered 
 
 ## Notes on Installation on Linux OS
 
-Most Linux distributions provide `iconv` functionalities as part of the base operating system library `libc`. In normal circumstances, no additional installation of `libiconv` may be required by downloading it from the GNU repository and building from the sources. If you observe such a behavior on your operating system, file an issue with OS details.
+Most Linux distributions provide `iconv` functionalities as part of the base operating system library `glibc`. In normal circumstances, no additional installation of `libiconv` should be required. If you observe such a behavior on your operating system, file an issue with OS details.

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -31,7 +31,7 @@ function validate_iconv(n, h)
     return ret == -1 % Csize_t && Libc.errno() == Libc.EILSEQ
 end
 
-libiconv = library_dependency("libiconv", aliases = ["libc", "iconv"],
+libiconv = library_dependency("libiconv", aliases = ["libc", "iconv", "libc-bin"],
                               validate = validate_iconv)
 
 if is_windows()

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -31,7 +31,7 @@ function validate_iconv(n, h)
     return ret == -1 % Csize_t && Libc.errno() == Libc.EILSEQ
 end
 
-libiconv = library_dependency("libiconv", aliases = ["libc", "iconv", "libc-bin"],
+libiconv = library_dependency("libiconv", aliases = ["libc", "libc-bin", "iconv"],
                               validate = validate_iconv)
 
 if is_windows()

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -40,9 +40,9 @@ if is_windows()
 end
 
 provides(Sources,
-         URI("http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz"),
+         URI("http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.15.tar.gz"),
          libiconv,
-         SHA="72b24ded17d687193c3366d0ebe7cde1e6b18f0df8c55438ac95be39e8a30613")
+         SHA="ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178")
 
 provides(BuildProcess,
          Autotools(libtarget = "lib/libiconv.la",


### PR DESCRIPTION
Added `libc-bin` to the alias list as that is how `libc` reported on Ubuntu 17.04. 