### PR TITLE
Fix handling of Shift_JISx0213

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StringEncodings"
 uuid = "69024149-9ee7-55f6-a4c4-859efe599b68"
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 Libiconv_jll = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"

--- a/src/StringEncodings.jl
+++ b/src/StringEncodings.jl
@@ -236,6 +236,7 @@ end
 function close(s::StringEncoder)
     flush(s)
     iconv_reset!(s)
+    write(s.stream, view(s.outbuf, 1:(BUFSIZE - Int(s.outbytesleft[]))))
     # Make sure C memory/resources are returned
     finalize(s)
     if s.closestream
@@ -518,7 +519,7 @@ function encode(s::AbstractString, enc::Encoding)
     b = IOBuffer()
     p = StringEncoder(b, enc, encoding(typeof(s)))
     write(p, s)
-    flush(p)
+    close(p)
     take!(b)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,10 +234,9 @@ mktemp() do path, io
     @test_throws ArgumentError open(path, enc"ISO-2022-JP", true, false, false, false, true)
 end
 
-@testset "Shift JIS (issue #49)" begin
+@testset "Bytes written only when closing with Shift JIS (issue #49)" begin
     for enc in ("SHIFT_JIS", "SHIFT_JISX0213")
-        @test encode("ク", enc) ==
-            [0x83, 0x4e]
+        @test encode("ク", enc) == [0x83, 0x4e]
 
         b = IOBuffer()
         s = StringEncoder(b, enc)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,6 +234,19 @@ mktemp() do path, io
     @test_throws ArgumentError open(path, enc"ISO-2022-JP", true, false, false, false, true)
 end
 
+@testset "Shift JIS (issue #49)" begin
+    for enc in ("SHIFT_JIS", "SHIFT_JISX0213")
+        @test encode("ク", enc) ==
+            [0x83, 0x4e]
+
+        b = IOBuffer()
+        s = StringEncoder(b, enc)
+        write(s, "ク")
+        close(s)
+        @test take!(b) == [0x83, 0x4e]
+    end
+end
+
 
 ## Test encodings support
 b = IOBuffer()


### PR DESCRIPTION
For stateful encodings, we need to copy the contents of the output buffer to the stream after calling `iconv_reset!`. Otherwise the bytes that may be written remain in the buffer. We als oneed to `close` from `encode`, which incidentally ensures that objects can be freed immediately.

Fix #49.